### PR TITLE
Added tracking for hung queries

### DIFF
--- a/app/jobs/monitor_job.rb
+++ b/app/jobs/monitor_job.rb
@@ -82,6 +82,9 @@ class MonitorJob < ActiveJob::Base
       if Fakes::AlwaysDownService.prevalidate
         monitor_services.push(Fakes::AlwaysDownService)
       end
+      if Fakes::HungService.prevalidate
+        monitor_services.push(Fakes::HungService)
+      end
 
     else
       puts "loading up production services\n\n\n\n"

--- a/app/services/monitor_service.rb
+++ b/app/services/monitor_service.rb
@@ -58,6 +58,8 @@ class MonitorService
   def failed
     @failed_rate_5 -= @failed_rate_5 / 5.0
     @failed_rate_5 += 1 / 5.0
+
+    self.update_prometheus_metrics
     save
   end
 

--- a/lib/fakes/hung_service.rb
+++ b/lib/fakes/hung_service.rb
@@ -1,0 +1,25 @@
+class Fakes::HungService < MonitorService
+  attr_accessor :last_result
+  @@service_name = "Hung"
+
+  def initialize
+    @name = @@service_name
+    @service = "Hung"
+    @api = "blockForever"
+    super
+  end
+
+  def self.service_name
+    @@service_name
+  end
+
+  def query_service
+    sleep 999999
+    @pass = false
+  end
+
+  def self.prevalidate
+    true
+  end
+
+end


### PR DESCRIPTION
Hung queries were not being tracked in Prometheus correctly. This PR addresses that.