### PR TITLE
Allow Route Prefix at the application level

### DIFF
--- a/app/assets/stylesheets/_main.scss
+++ b/app/assets/stylesheets/_main.scss
@@ -7,28 +7,28 @@
 
 
 .cf-logo-image-default {
-  background-image: url(asset-path('caseflow-monitor-logo.svg'));
+  background-image: asset_url('caseflow-monitor-logo.svg');
   width: 32px;
   height: 32px;
   background-size: 32px 32px;
 }
 
 .cf-logo-image-monitor {
-  background-image: url(asset-path('caseflow-monitor-logo.svg'));
+  background-image: asset_url('caseflow-monitor-logo.svg');
   width: 32px;
   height: 32px;
   background-size: 32px 32px;
 }
 
 .monitor-warning-icon {
-  background-image: url(asset-path('warning.svg'));
+  background-image: asset_url('warning.svg');
   width: 32px;
   height: 32px;
   background-size: 32px 32px;
 }
 
 body {
-  font-size: 1.5rem;
+  font-size: 1.5rem; 
 }
 
 .feedback {

--- a/app/views/monitor/index.html.erb
+++ b/app/views/monitor/index.html.erb
@@ -9,7 +9,7 @@
   function pollForMetrics() {
     $.ajax({
       dataType: "json",
-      url: 'sample',
+      url: "<%= Rails.application.config.app_url_prefix %>/sample",
       success: function(data) {
         $( "#monitor-metrics" ).html("");
         var count = 0;

--- a/config/application.rb
+++ b/config/application.rb
@@ -55,5 +55,13 @@ module CaseflowMonitor
       config.autoload_paths += Dir[Rails.root.join('lib', 'fakes')]
     end
 
+    if ENV['APP_URL_PREFIX'] == nil
+      config.app_url_prefix = "";
+    else
+      config.app_url_prefix = ENV['APP_URL_PREFIX'];
+    end
+    
+    config.action_controller.relative_url_root = "#{config.app_url_prefix}/assets";
+    config.assets.prefix = "#{config.app_url_prefix}/assets";
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -52,4 +52,5 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
   config.log_level = :debug
+  
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,10 @@
 Rails.application.routes.draw do
 
-  resource :monitor
+  root :to => redirect("#{Rails.application.config.app_url_prefix}")
 
-  resource :info
-
-  get "sample" => "sample#index"
-
-  root 'monitor#index'
+  scope "#{Rails.application.config.app_url_prefix}" do
+    get "/" => 'monitor#index'
+    get "/sample" => 'sample#index'
+  end
 
 end


### PR DESCRIPTION
This change allows the URL to be prefixed for assets, views and APIs through `APP_URL_PREFIX` environment variable.

The change is designed for co-existing several Monitor servers behind a single Nginx proxy.