### PR TITLE
Display env information to all endpoint

### DIFF
--- a/app/services/bgs_service.rb
+++ b/app/services/bgs_service.rb
@@ -10,6 +10,7 @@ class BGSService < MonitorService
 
     @name = @@service_name
     @service = "Person"
+    @env = ENV['BGS_ENVIRONMENT=']
     @api = "findPersonByFileNumber"
     super
   end

--- a/app/services/monitor_service.rb
+++ b/app/services/monitor_service.rb
@@ -17,6 +17,10 @@ class MonitorService
       @count = 0
       @failed_rate_5 = 0
       @pass = false
+
+      if @env == nil
+        @env = ENV['DEPLOY_ENV']
+      end
     else
       @time = last_result[:time]
       @latency = last_result[:latency] || 0
@@ -35,6 +39,7 @@ class MonitorService
   def save
     last_result = {
       name: @name,
+      env: @env,
       time: @time,
       latency: @latency,
       service: @service,

--- a/app/services/vacols_service.rb
+++ b/app/services/vacols_service.rb
@@ -8,6 +8,7 @@ class VacolsService < MonitorService
 
     @name = @@service_name
     @service = "VACOLS"
+    @env = ENV['VACOLS_HOST=']
     @api = "VACOLS.BRIEFF"
     super
   end

--- a/app/services/vbms_service.rb
+++ b/app/services/vbms_service.rb
@@ -8,6 +8,7 @@ class VBMSService < MonitorService
 
     @name = @@service_name
     @service = "VBMS"
+    @env = ENV['CONNECT_VBMS_ENV=']
     @api = "ListDocuments"
 
     @client = VBMS::Client.from_env_vars(

--- a/app/views/monitor/index.html.erb
+++ b/app/views/monitor/index.html.erb
@@ -94,6 +94,14 @@
         </div>
         <div class="monitor-metric">
           <span class="monitor-metric-label">
+            Env:
+          </span>
+          <span class="monitor-metric-value">
+            {{env}}
+          </span>
+        </div>
+        <div class="monitor-metric">
+          <span class="monitor-metric-label">
             Latency:
           </span>
           <span class="monitor-metric-value">

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -5,6 +5,7 @@ class Fakes::BGSService < MonitorService
   def initialize
     @name = @@service_name
     @service = "Person"
+    @env = "beplinktest"
     @api = "findPersonByFileNumber"
     super
   end

--- a/lib/fakes/vacols_service.rb
+++ b/lib/fakes/vacols_service.rb
@@ -5,6 +5,7 @@ class Fakes::VacolsService < MonitorService
   def initialize    
     @name = @@service_name
     @service = "VACOLS"
+    @env = "dev"
     @api = "VACOLS.BRIEFF"
     super
   end

--- a/lib/fakes/vbms_service.rb
+++ b/lib/fakes/vbms_service.rb
@@ -5,6 +5,7 @@ class Fakes::VBMSService < MonitorService
   def initialize    
     @name = @@service_name
     @service = "VBMS"
+    @env = "uat"
     @api = "ListDocuments"
     super
   end


### PR DESCRIPTION
Now that we are supporting uat/preprod/prod, the backend endpoint gets confusing.

The env for each service is now displayed explicitly in each block.

![image](https://cloud.githubusercontent.com/assets/3258724/25865519/263da7a2-34c1-11e7-9c59-5d9aae25a149.png)
