### PR TITLE
Locking down the Jenkins node for deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ def APP_VERSION = 'HEAD'
 /************************ Common Pipeline boilerplate ************************/
 
 def commonPipeline;
-node {
+node ('deploy') {
 
   // withCredentials allows us to expose the secrets in Credential Binding
   // Plugin to get the credentials from Jenkins secrets.


### PR DESCRIPTION
The recent Jenkins reconfiguration requires application to use the `deploy` node for the deploy pipeline.