### PR TITLE
Recover VACOLS connection to each query

### DIFF
--- a/app/services/monitor_service.rb
+++ b/app/services/monitor_service.rb
@@ -86,7 +86,7 @@ class MonitorService
     if @pass == true
       @latency = latency
     else
-      # force latency to be 0 so that it is obvious in prometheus were the errors are
+      # force latency to be 0 so that it is obvious in prometheus where the errors were
       @latency = 0
     end
 

--- a/app/services/monitor_service.rb
+++ b/app/services/monitor_service.rb
@@ -83,7 +83,12 @@ class MonitorService
       end
     end
 
-    @latency = latency
+    if @pass == true
+      @latency = latency
+    else
+      # force latency to be 0 so that it is obvious in prometheus were the errors are
+      @latency = 0
+    end
 
     if @count < 10
       @latency10 -= @latency10 / @count

--- a/app/services/vacols_service.rb
+++ b/app/services/vacols_service.rb
@@ -48,6 +48,9 @@ class VacolsService < MonitorService
         puts "VACOLS connection dropped, reconnecting on next query"
         @connection = nil
       end
+
+      # Propagate the exception up the stack to fail this query. This way, the 
+      # failure will be recorded in Prometheus / Grafana.
       raise
     end
 

--- a/app/services/vacols_service.rb
+++ b/app/services/vacols_service.rb
@@ -22,12 +22,35 @@ class VacolsService < MonitorService
     @@service_name
   end
 
+  # A list of OCI error code that determines Oracle connectivity issues.
+  # ORA-00028: your session has been killed
+  # ORA-01012: not logged on
+  # ORA-03113: end-of-file on communication channel
+  # ORA-03114: not connected to ORACLE
+  # ORA-03135: connection lost contact
+  # See # From https://github.com/rsim/oracle-enhanced/blob/d990f945de4d972833487b1b3364a5d013549c7f/lib/active_record/connection_adapters/oracle_enhanced/oci_connection.rb#L420
+  LOST_CONNECTION_ERROR_CODES = [ 28, 1012, 3113, 3114, 3135 ] #:nodoc:
+
   def query_service
     if @connection == nil
       ActiveRecord::Base.establish_connection(:production_vacols)
       @connection = ActiveRecord::Base.connection
     end
-    array = @connection.exec_query("SELECT * FROM VACOLS.BRIEFF WHERE BFKEY=TO_CHAR(#{Rails.application.secrets.target_file_num})")
+
+    begin
+      array = @connection.exec_query(
+        "SELECT * FROM VACOLS.BRIEFF WHERE BFKEY=TO_CHAR(#{Rails.application.secrets.target_file_num})")
+    rescue => e
+      # If this is a connectivity issue, reset the connection pointer and
+      # force the connection to be re-established in the next query.
+      if e.original_exception.is_a?(OCIError) && 
+        LOST_CONNECTION_ERROR_CODES.include?(e.original_exception.code)
+        puts "VACOLS connection dropped, reconnecting on next query"
+        @connection = nil
+      end
+      raise
+    end
+
     @pass = true
   end
 end


### PR DESCRIPTION
This change allows the VACOLS poller to recover from connection failure. 

If VACOLS connections are dropped, the following will be done.
 - Mark the current query to be a failure so it shows up in Prometheus
 - Try to reconnect to VACOLS on the _next_ query attempt.

Connects https://github.com/department-of-veterans-affairs/caseflow-monitor/issues/15