### PR TITLE
Added DMS time tagging

### DIFF
--- a/app/services/vacols_service.rb
+++ b/app/services/vacols_service.rb
@@ -117,6 +117,13 @@ class VacolsService < MonitorService
         name: 'caseflow_db_time_24hrs'
       }, caseflow_db_time_24hrs[0]['dbtime'])
 
+      # Update a test note periodically with a timestamp to verify that DMS 
+      # replication is running as expected.
+      dms_update = <<-EQL
+        update VACOLS.CORRES set SNOTES= (to_char(SYSDATE, 'YYYY-MM-DD HH24:MI:SS')) 
+        where STAFKEY='#{Rails.application.secrets.dms_checker_staff_key}'
+      EQL
+      @connection.execute(dms_update)
     rescue => e
       Rails.logger.warn(e.message)
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -14,6 +14,7 @@ development:
   secret_key_base: 04a0351cab89c791a1cd8fde430a586110737610f31eee5a5b86ae3e405d71955891ac3f55382dc54102ad4fba25f62d920c61e93a6c1be321c8bef4c1d5ad4d
   target_file_num: <%= ENV["TARGET_FILE_NUM"] %>
   vva_file_num: <%= ENV["VVA_FILE_NUM"] %>
+  dms_checker_staff_key: <%= ENV["DMS_CHECKER_STAFF_KEY"] %>
 
 test:
   secret_key_base: 1e492dc138f683c6e253cc0ab8db2fdad7f4616995f18d06f9d578429fcccf56cb4ed1be9a0af2a07c77069ab02f9ef6a3c15542483f42d5e6246f6736240f48
@@ -24,3 +25,4 @@ production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   target_file_num: <%= ENV["TARGET_FILE_NUM"] %>
   vva_file_num: <%= ENV["VVA_FILE_NUM"] %>
+  dms_checker_staff_key: <%= ENV["DMS_CHECKER_STAFF_KEY"] %>


### PR DESCRIPTION
Every time we poll VACOLS, we write a timestamp to one of the staffkey. This way, we will force a change every 10-20s and have a way to detect DMS health.