### PR TITLE
Fix BGS Address Sevice

### DIFF
--- a/app/services/bgs_address_service.rb
+++ b/app/services/bgs_address_service.rb
@@ -17,8 +17,8 @@ class BGSAddressService < MonitorService
 
   def query_service
     participant_id = Rails.application.secrets.participant_ids.split(",").sample.strip
-    address = @bgs_client.address.find_by_participant_id(participant_id)
-    if !address[:city_nm].blank?
+    address = @bgs_client.address.find_all_by_participant_id(participant_id)
+    if !address.nil?
       @pass = true
     end
   end


### PR DESCRIPTION
We are using the wrong service:
https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/services/external_api/bgs_service.rb#L71

Caseflow uses `find_all`

```
BGS.OrganizationPoaService query started
I, [2017-11-21T17:15:19.116796 #9548]  INFO -- : BGS.OrganizationPoaService query done
I, [2017-11-21T17:15:19.954611 #9548]  INFO -- : BGS.AddressService query started
I, [2017-11-21T17:15:20.429552 #9548]  INFO -- : BGS.BenefitsService query started
I, [2017-11-21T17:15:20.531607 #9548]  INFO -- : BGS.AddressService query done
I, [2017-11-21T17:15:20.541805 #9548]  INFO -- : BGS.ClaimantGeneralInfoService query started
I, [2017-11-21T17:15:20.575848 #9548]  INFO -- : BGS.PersonFilenumberService query started
I, [2017-11-21T17:15:20.966460 #9548]  INFO -- : BGS.BenefitsService query done
I, [2017-11-21T17:15:21.005179 #9548]  INFO -- : BGS.PersonFilenumberService query done
I, [2017-11-21T17:15:21.098368 #9548]  INFO -- : BGS.ClaimantGeneralInfoService query done
```