### PR TITLE
Change FindDocumentSeriesReference to FindDocumentVersionReference

### DIFF
--- a/app/jobs/monitor_job.rb
+++ b/app/jobs/monitor_job.rb
@@ -77,7 +77,7 @@ class MonitorJob < ActiveJob::Base
         Fakes::BGSVeteranService,
         Fakes::VacolsService,
         Fakes::VBMSService,
-        Fakes::VBMSServiceFindDocumentReferenceSeries,
+        Fakes::VBMSServiceFindDocumentVersionReference,
         Fakes::VVAService,
         Fakes::LaggyService,
         Fakes::UnreliableService,
@@ -96,7 +96,7 @@ class MonitorJob < ActiveJob::Base
         BGSVeteranService,
         VacolsService,
         VBMSService,
-        VBMSServiceFindDocumentReferenceSeries,
+        VBMSServiceFindDocumentVersionReference,
         VVAService
       ]
     end

--- a/app/services/vbms_service_find_document_version_reference.rb
+++ b/app/services/vbms_service_find_document_version_reference.rb
@@ -1,14 +1,14 @@
 require 'vbms'
 
-class VBMSServiceFindDocumentReferenceSeries < MonitorService
-  @@service_name = "VBMS.FindDocumentSeriesReference"
+class VBMSServiceFindDocumentVersionReference < MonitorService
+  @@service_name = "VBMS.FindDocumentVersionReference"
 
   def initialize
     @connection = nil
 
     @name = @@service_name
     @service = "VBMS"
-    @api = "FindDocumentSeriesReference"
+    @api = "FindDocumentVersionReference"
 
     @client = VBMS::Client.from_env_vars(
       env_name: ENV["CONNECT_VBMS_ENV"],
@@ -28,7 +28,7 @@ class VBMSServiceFindDocumentReferenceSeries < MonitorService
 
   def query_service
     filenum = Rails.application.secrets.target_file_num.split(",").sample.strip
-    request = VBMS::Requests::FindDocumentSeriesReference.new(filenum)
+    request = VBMS::Requests::FindDocumentVersionReference.new(filenum)
     doc = @client.send_request(request)
     if doc.length > 0
       @pass = true

--- a/lib/fakes/vbms_service_find_document_version_reference.rb
+++ b/lib/fakes/vbms_service_find_document_version_reference.rb
@@ -1,11 +1,11 @@
-class Fakes::VBMSServiceFindDocumentReferenceSeries < MonitorService
+class Fakes::VBMSServiceFindDocumentVersionReference < MonitorService
   attr_accessor :last_result
-  @@service_name = "VBMS.FindDocumentReferenceSeries"
+  @@service_name = "VBMS.FindDocumentVersionReference"
 
-  def initialize    
+  def initialize
     @name = @@service_name
     @service = "VBMS"
-    @api = "FindDocumentReferenceSeries"
+    @api = "FindDocumentVersionReference"
     super
   end
 


### PR DESCRIPTION
We are going to use FindDocumentVersionReference service instead of FindDocumentSeriesReference. 