### PR TITLE
sending metrics to datadog for consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 # Ignore Byebug command history file.
 .byebug_history
 .env
+
+# Ignore RubyMine files
+.idea

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'prometheus-client'
 
 gem 'tzinfo-data'
 
+# Sending metrics to DataDog
 gem 'dogapi'
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ gem 'prometheus-client'
 
 gem 'tzinfo-data'
 
+gem 'dogapi'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,8 @@ GEM
     d3-rails (4.7.0)
       railties (>= 3.1)
     debug_inspector (0.0.2)
+    dogapi (1.29.0)
+      multi_json
     dotenv (2.1.2)
     dotenv-rails (2.1.2)
       dotenv (= 2.1.2)
@@ -264,6 +266,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   connect_vbms!
   connect_vva!
+  dogapi
   dotenv-rails
   jbuilder (~> 2.5)
   jquery-rails
@@ -281,4 +284,4 @@ DEPENDENCIES
   web-console (>= 3.3.0)
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/app/services/monitor_service.rb
+++ b/app/services/monitor_service.rb
@@ -179,9 +179,9 @@ class MonitorService
 
     @dog.batch_metrics do
       @dog.emit_point("#{@name}.#{@api}.#{@env}.latency_summary","#{@latency}", 
-        options[:tags] = ["name:#{@name}", "api:#{@api}", "env:#{@env}"])
+        :tags => ["name:#{@name}", "api:#{@api}", "env:#{@env}"])
       @dog.emit_point("#{@name}.#{@api}.#{@env}.latency_gauge","#{@latency}", 
-        :tags =>  ["name:#{@name}", "api:#{@api}", "env:#{@env}"])
+        :tags => ["name:#{@name}", "api:#{@api}", "env:#{@env}"])
     end
 
     if @pass == true

--- a/app/services/monitor_service.rb
+++ b/app/services/monitor_service.rb
@@ -181,15 +181,15 @@ class MonitorService
       @dog.emit_point("#{@name}.#{@api}.#{@env}.latency_summary","#{@latency}", 
         options[:tags] = ["name:#{@name}", "api:#{@api}", "env:#{@env}"])
       @dog.emit_point("#{@name}.#{@api}.#{@env}.latency_gauge","#{@latency}", 
-        options[:tags] = ["name:#{@name}", "api:#{@api}", "env:#{@env}"])
+        :tags =>  ["name:#{@name}", "api:#{@api}", "env:#{@env}"])
     end
 
     if @pass == true
       @dog.emit_point("#{@name}.#{@api}.#{@env}.successful_query_total","1", 
-        options[:tags] = ["name:#{@name}", "api:#{@api}", "env:#{@env}"])
+        :tags => ["name:#{@name}", "api:#{@api}", "env:#{@env}"])
     else
       @dog.emit_point("#{@name}.#{@api}.#{@env}.failed_query_total","1", 
-        options[:tags] = ["name:#{@name}", "api:#{@api}", "env:#{@env}"])
+        :tags => ["name:#{@name}", "api:#{@api}", "env:#{@env}"])
     end
   end
 end

--- a/app/services/monitor_service.rb
+++ b/app/services/monitor_service.rb
@@ -1,13 +1,19 @@
+gem 'dogapi'
+
 class MonitorService
 
   attr_accessor :name, :polling_rate_sec, :time
 
   @@name = "Unamed"
+
   def initialize
 
     # Read from last result cache, and use that as base line if it exists.
     last_result = Rails.cache.read(@name)
 
+    # Initialize dog so sub classes can use it as well as this parent abstract class
+    dd_api_key = ENV["DD_API_KEY"]
+    @dog = Dogapi::Client.new(dd_api_key)
 
     if last_result == nil
       @time = 0
@@ -65,6 +71,7 @@ class MonitorService
     @failed_rate_5 += 1 / 5.0
 
     self.update_prometheus_metrics
+    self.update_datadog_metrics
     save
   end
 
@@ -109,6 +116,7 @@ class MonitorService
     @latency = latency
 
     self.update_prometheus_metrics
+    self.update_datadog_metrics
 
     save
 
@@ -164,5 +172,24 @@ class MonitorService
     # Implement the details of the query here.
     # Set @pass to true/false according to the query result.
     raise NotImplementedError.new("Implement the details of the query here")
+  end
+
+  ## Update Datadog metrics or creates them
+  def update_datadog_metrics
+
+    @dog.batch_metrics do
+      @dog.emit_point("#{@name}.#{@api}.#{@env}.latency_summary","#{@latency}", 
+        options[:tags] = ["name:#{@name}", "api:#{@api}", "env:#{@env}"])
+      @dog.emit_point("#{@name}.#{@api}.#{@env}.latency_gauge","#{@latency}", 
+        options[:tags] = ["name:#{@name}", "api:#{@api}", "env:#{@env}"])
+    end
+
+    if @pass == true
+      @dog.emit_point("#{@name}.#{@api}.#{@env}.successful_query_total","1", 
+        options[:tags] = ["name:#{@name}", "api:#{@api}", "env:#{@env}"])
+    else
+      @dog.emit_point("#{@name}.#{@api}.#{@env}.failed_query_total","1", 
+        options[:tags] = ["name:#{@name}", "api:#{@api}", "env:#{@env}"])
+    end
   end
 end

--- a/app/services/vacols_service.rb
+++ b/app/services/vacols_service.rb
@@ -74,7 +74,7 @@ class VacolsService < MonitorService
           name: wtc['wait_event']
         }, wtc['total_wait_time'])
         @dog.emit_point("vacols_performance", "#{wtc['total_wait_time']}", 
-          options[:tags] = ["name:#{wtc['wait_event']}", "env:#{@env}", "source:ash"])
+          :tags => ["name:#{wtc['wait_event']}", "env:#{@env}", "source:ash"])
       end
     
       # Overall system time that includes DB Time, DB CPU and various metrics

--- a/app/services/vacols_service.rb
+++ b/app/services/vacols_service.rb
@@ -89,7 +89,7 @@ class VacolsService < MonitorService
           name: stm['stat_name']
         }, stm['time'])
         @dog.emit_point("vacols_performance", "#{stm['time']}",
-           options[:tags] = ["name:#{stm['stat_name']}", "env:#{@env}", "source:sys_time_model"])
+          :tags => ["name:#{stm['stat_name']}", "env:#{@env}", "source:sys_time_model"])
       end
 
 
@@ -107,7 +107,7 @@ class VacolsService < MonitorService
         name: 'sum_all_db_time_24hrs'
       }, sum_all_db_time_24hrs[0]['dbtime'])
       @dog.emit_point("vacols_performance", "#{sum_all_db_time_24hrs[0]['dbtime']}", 
-        options[:tags] = ["name:sum_all_db_time_24hrs", "env:#{@env}", "source:ash"])
+        :tags => ["name:sum_all_db_time_24hrs", "env:#{@env}", "source:ash"])
 
       # Summing Caseflow DB Time from ASH table
       caseflow_db_time_24hrs = @connection.exec_query(<<-EQL)
@@ -123,7 +123,7 @@ class VacolsService < MonitorService
         name: 'caseflow_db_time_24hrs'
       }, caseflow_db_time_24hrs[0]['dbtime'])
       @dog.emit_point("vacols_performance", "#{caseflow_db_time_24hrs[0]['dbtime']}", 
-        options[:tags] = ["name:caseflow_db_time_24hrs", "env:#{@env}", "source:ash"])
+        :tags => ["name:caseflow_db_time_24hrs", "env:#{@env}", "source:ash"])
 
       # Update a test note periodically with a timestamp to verify that DMS 
       # replication is running as expected.

--- a/app/services/vacols_service.rb
+++ b/app/services/vacols_service.rb
@@ -74,7 +74,7 @@ class VacolsService < MonitorService
           name: wtc['wait_event']
         }, wtc['total_wait_time'])
         @dog.emit_point("vacols_performance", "#{wtc['total_wait_time']}", 
-          options[:tags] = ["name:#{wtc['wait_event']}", "env:#{@env}", "source:ash")
+          options[:tags] = ["name:#{wtc['wait_event']}", "env:#{@env}", "source:ash"])
       end
     
       # Overall system time that includes DB Time, DB CPU and various metrics

--- a/app/services/vacols_service.rb
+++ b/app/services/vacols_service.rb
@@ -89,7 +89,7 @@ class VacolsService < MonitorService
           name: stm['stat_name']
         }, stm['time'])
         @dog.emit_point("vacols_performance", "#{stm['time']}",
-           options[:tags] = ["name:#{stm['stat_name']}", "env:#{@env}", "source:sys_time_model")
+           options[:tags] = ["name:#{stm['stat_name']}", "env:#{@env}", "source:sys_time_model"])
       end
 
 
@@ -107,7 +107,7 @@ class VacolsService < MonitorService
         name: 'sum_all_db_time_24hrs'
       }, sum_all_db_time_24hrs[0]['dbtime'])
       @dog.emit_point("vacols_performance", "#{sum_all_db_time_24hrs[0]['dbtime']}", 
-        options[:tags] = ["name:sum_all_db_time_24hrs", "env:#{@env}", "source:ash")
+        options[:tags] = ["name:sum_all_db_time_24hrs", "env:#{@env}", "source:ash"])
 
       # Summing Caseflow DB Time from ASH table
       caseflow_db_time_24hrs = @connection.exec_query(<<-EQL)
@@ -123,7 +123,7 @@ class VacolsService < MonitorService
         name: 'caseflow_db_time_24hrs'
       }, caseflow_db_time_24hrs[0]['dbtime'])
       @dog.emit_point("vacols_performance", "#{caseflow_db_time_24hrs[0]['dbtime']}", 
-        options[:tags] = ["name:caseflow_db_time_24hrs", "env:#{@env}", "source:ash")
+        options[:tags] = ["name:caseflow_db_time_24hrs", "env:#{@env}", "source:ash"])
 
       # Update a test note periodically with a timestamp to verify that DMS 
       # replication is running as expected.

--- a/app/services/vacols_service.rb
+++ b/app/services/vacols_service.rb
@@ -73,6 +73,8 @@ class VacolsService < MonitorService
           source: 'ash',
           name: wtc['wait_event']
         }, wtc['total_wait_time'])
+        @dog.emit_point("vacols_performance", "#{wtc['total_wait_time']}", 
+          options[:tags] = ["name:#{wtc['wait_event']}", "env:#{@env}", "source:ash")
       end
     
       # Overall system time that includes DB Time, DB CPU and various metrics
@@ -86,6 +88,8 @@ class VacolsService < MonitorService
           source: 'sys_time_model',
           name: stm['stat_name']
         }, stm['time'])
+        @dog.emit_point("vacols_performance", "#{stm['time']}",
+           options[:tags] = ["name:#{stm['stat_name']}", "env:#{@env}", "source:sys_time_model")
       end
 
 
@@ -102,6 +106,8 @@ class VacolsService < MonitorService
         source: 'ash',
         name: 'sum_all_db_time_24hrs'
       }, sum_all_db_time_24hrs[0]['dbtime'])
+      @dog.emit_point("vacols_performance", "#{sum_all_db_time_24hrs[0]['dbtime']}", 
+        options[:tags] = ["name:sum_all_db_time_24hrs", "env:#{@env}", "source:ash")
 
       # Summing Caseflow DB Time from ASH table
       caseflow_db_time_24hrs = @connection.exec_query(<<-EQL)
@@ -116,6 +122,8 @@ class VacolsService < MonitorService
         source: 'ash',
         name: 'caseflow_db_time_24hrs'
       }, caseflow_db_time_24hrs[0]['dbtime'])
+      @dog.emit_point("vacols_performance", "#{caseflow_db_time_24hrs[0]['dbtime']}", 
+        options[:tags] = ["name:caseflow_db_time_24hrs", "env:#{@env}", "source:ash")
 
       # Update a test note periodically with a timestamp to verify that DMS 
       # replication is running as expected.


### PR DESCRIPTION
Issue: https://github.com/department-of-veterans-affairs/caseflow-monitor/issues/52

The issue stated to only send VACOLS Performance data, particularly the ASH table, but for consistency, I decided after talking to Lisa and Alan, that maybe the best approach would be to also send all the other metrics.

If this is not the right approach, please let me know.
I have tested this locally with some fake numbers, this has not been tested outside of that scope. Will need to deploy it to UAT / Stage to validate if it works correctly.