### PR TITLE
update version of connect_vbms for SHA256 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ end
 
 
 group :production do
-  gem 'connect_vbms', git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", branch: 'master'
+  gem 'connect_vbms', git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", branch: 'lisac/sha256_partial_upgrade'
   gem 'connect_vva', git: "https://github.com/department-of-veterans-affairs/connect_vva.git", branch: 'master'
   gem 'bgs', git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", branch: 'master'
   gem 'activerecord-oracle_enhanced-adapter', '~> 1.7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,8 +13,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vbms.git
-  revision: 5dda05573d424d557be7a09052ab24b0dc6a5c5f
-  branch: master
+  revision: 81a9ad521f96a23e5a483cbc914cc9ec3331a52e
+  branch: lisac/sha256_partial_upgrade
   specs:
     connect_vbms (1.0.0)
       httpclient (~> 2.8.0)


### PR DESCRIPTION
use a version of connect_vbms that uses SHA256 based on env variable

connects to https://github.com/department-of-veterans-affairs/connect_vbms/pull/178 