### PR TITLE
Adding TraceRoute Monitor

### DIFF
--- a/app/jobs/monitor_job.rb
+++ b/app/jobs/monitor_job.rb
@@ -95,7 +95,8 @@ class MonitorJob < ActiveJob::Base
         BGSVeteranService,
         VacolsService,
         VBMSServiceFindDocumentVersionReference,
-        VVAService
+        VVAService,
+        TraceRouteService
       ]
     end
     services.each do |service|

--- a/app/services/trace_route_service.rb
+++ b/app/services/trace_route_service.rb
@@ -41,7 +41,7 @@ class TraceRouteService
   end
 
   def query
-    output = `sudo traceroute -T #{ENV["VACOLS_HOST"]}`
+    output = `traceroute -T #{ENV["VACOLS_HOST"]}`
 
     lines = output.split("\n")
     endpoint_latencies = lines.map do |line|
@@ -68,7 +68,7 @@ class TraceRouteService
     @data_dog.batch_metrics do
       endpoint_latencies.values.each do |latency|
         latency[:latencies].each do |value|
-          
+
           @data_dog.emit_point(
             "traceroute.#{ENV['DEPLOY_ENV']}.latency_summary",
             value,

--- a/app/services/trace_route_service.rb
+++ b/app/services/trace_route_service.rb
@@ -32,6 +32,10 @@ class TraceRouteService
     @name = @@service_name
   end
 
+  def self.prevalidate
+    true
+  end
+
   def self.service_name
     @@service_name
   end

--- a/app/services/trace_route_service.rb
+++ b/app/services/trace_route_service.rb
@@ -20,7 +20,7 @@ class TraceRouteService
     "205" => "Philadelphia",
     "204" => "Hines, IL",
     "206" => "PITC (Philadelphia)",
-    "222" => "VACO MAN/Users",
+    "222" => "VACOLS",
     "240" => "AWS GovCloud West 1 Transit VPC",
     "241" => "AWS GovCloud West 1 tunneling to TIC GWN",
     "242" => "AWS GovCloud West 1 tunneling to TIC GWE",

--- a/app/services/trace_route_service.rb
+++ b/app/services/trace_route_service.rb
@@ -1,0 +1,76 @@
+gem 'dogapi'
+
+class TraceRouteService
+  attr_accessor :last_result, :name
+
+  REG_EX = /\((\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b)\)(?:\s*(\d*\.?\d*)\s*ms)?(?:\s*(\d*\.?\d*)\s*ms)?(?:\s*(\d*\.?\d*)\s*ms)?/
+  IP_MAPPING = {
+    "208" => "EWIS (CRRC)",
+    "209" => "EWIS (CRRC)",
+    "224" => "AITC",
+    "244" => "Terremark",
+    "245" => "Azure East",
+    "234" => "GWE hosted services",
+    "237" => "GWN (or remote access)",
+    "238" => "GWE (or remote access)",
+    "250" => "GW(N/S/W/E) Cisco ASR interface to WLAN",
+    "205" => "Philadelphia",
+    "204" => "Hines, IL",
+    "206" => "PITC (Philadelphia)",
+    "222" => "VACO MAN/Users",
+    "240" => "AWS GovCloud West 1 Transit VPC",
+    "241" => "AWS GovCloud West 1 tunneling to TIC GWN",
+    "242" => "AWS GovCloud West 1 tunneling to TIC GWE",
+    "247" => "AWS GovCloud West 1 Spoke tenants"
+  }.freeze
+
+  def initialize
+    @data_dog = Dogapi::Client.new(ENV["DD_API_KEY"])
+  end
+
+  def query
+    #ENV["VACOLS_HOST"]
+    output = `sudo traceroute -T #{ENV["VACOLS_HOST"]}`
+
+    lines = output.split("\n")
+    latencies = lines.map do |line|
+      line.scan(REG_EX)
+    end.flatten(1).reduce({}) do |object, groups|
+      ip = groups.first
+      match_data = ip.match(/10\.(\d{1,3})/)
+      second_octet = match_data ? match_data[1] : nil
+      latency_values = groups[1..-1].compact
+
+      if (object[ip])
+        object[ip][:latencies].concat(latency_values)
+      else
+        object[ip] = {
+          ip: ip,
+          tag: IP_MAPPING[second_octet] || "unknown",
+          latencies: latency_values
+        }
+      end
+
+      object
+    end
+
+    @data_dog.batch_metrics do
+      latencies.values.each do |latency|
+        latency[:latencies].each do |value|
+          
+          @data_dog.emit_point(
+            "traceroute.#{ENV['DEPLOY_ENV']}.latency_summary",
+            value,
+            :tags => ["va_network_endpoint:#{latency[:tag]}", "url:#{latency[:ip]}"].compact
+          )
+        end
+      end
+    end
+
+    true
+  end
+
+  def failed
+    # We need to define a failed method, since monitor_job can call it
+  end
+end


### PR DESCRIPTION
In order to measure latency to points in the VA this PR adds a TraceRoute monitor. Every 30 seconds Monitor will now run `traceroute -T #{ENV["VACOLS_HOST"]}`. The result of this query will be parsed to determine the latency of hitting various IPs in the VA network. We then parse the second octet in each IP to determine where in the network it is based on this mapping:

```
  IP_MAPPING = {
    "208" => "EWIS (CRRC)",
    "209" => "EWIS (CRRC)",
    "224" => "AITC",
    "244" => "Terremark",
    "245" => "Azure East",
    "234" => "GWE hosted services",
    "237" => "GWN (or remote access)",
    "238" => "GWE (or remote access)",
    "250" => "GW(N/S/W/E) Cisco ASR interface to WLAN",
    "205" => "Philadelphia",
    "204" => "Hines, IL",
    "206" => "PITC (Philadelphia)",
    "222" => "VACO MAN/Users",
    "240" => "AWS GovCloud West 1 Transit VPC",
    "241" => "AWS GovCloud West 1 tunneling to TIC GWN",
    "242" => "AWS GovCloud West 1 tunneling to TIC GWE",
    "247" => "AWS GovCloud West 1 Spoke tenants"
  }.freeze
```

This data is all sent to DataDog, with the `va_network_endpoint` tag set to the strings in the above mapping, and `url` set to the ip hit.

![screen shot 2018-11-27 at 5 12 12 pm](https://user-images.githubusercontent.com/3885236/49115015-9dee6600-f267-11e8-8c97-fff3672ad961.png)
