### PR TITLE
Turn make migrate into a no-op

### DIFF
--- a/Makefile.example
+++ b/Makefile.example
@@ -8,6 +8,7 @@ db-migrate: migrate
 etl-migrate: migrate
 
 migrate:
-	bundle exec rake db:migrate
+	@echo "This application does not have migrations"
+	@exit 0
 
 .PHONY: db-migrate etl-migrate


### PR DESCRIPTION
Rails 5.2 seems to want to write to a db that we do not use, since we have zero migrations.

If we ever have actual migrations in this app, this make target would need to revert.