### PR TITLE
Updates Gemfile.lock to mimemagic 0.3.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.4)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)


### PR DESCRIPTION
Resolves https://jenkins.uat.appeals.va.gov/job/bakes/job/prod/job/efolder/169/console failed build

### Description
Updates Gemfile.lock to mimemagic 0.3.6

See https://github.com/minad/mimemagic/issues/98

0.3.5 was yanked from the Internet due to a licensing issue, and an 0.4.0 version was released. But ActiveStorage depends on marcel which depends on 0.3.x, so an 0.3.6 version was released.

```
    marcel (0.3.3)
      mimemagic (~> 0.3.2)
```

This version GPL2 licensed. This appears to be a non-issue for our case but IANAL.