### PR TITLE
Upgrade mimemagic and BGS

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,13 +35,13 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/ruby-bgs.git
-  revision: 794811107e580321a4b8838c85027ad2fa9136a2
+  revision: 98547485d863f2f0d3bb9a1b9ec92a8fe21ba306
   branch: master
   specs:
-    bgs (0.2)
+    bgs (0.3)
       httpclient
-      nokogiri (~> 1.10.4)
-      savon (~> 2.12)
+      nokogiri
+      savon
 
 GEM
   remote: https://rubygems.org/
@@ -147,9 +147,10 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.4)
+    mimemagic (0.3.7)
+      nokogiri (~> 1.11.2)
     mini_mime (1.0.2)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.5.0)
     minitest (5.14.0)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
@@ -158,13 +159,15 @@ GEM
       bourbon (>= 4.0)
       sass (>= 3.3)
     nio4r (2.5.2)
-    nokogiri (1.10.9)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.11.2)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
     nori (2.6.0)
     pry (0.13.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
     puma (3.12.6)
+    racc (1.5.2)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -287,4 +290,4 @@ DEPENDENCIES
   web-console (>= 3.4.0)
 
 BUNDLED WITH
-   1.17.1
+   1.17.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,8 +40,8 @@ GIT
   specs:
     bgs (0.3)
       httpclient
-      nokogiri
-      savon
+      nokogiri (>= 1.11.0.rc4)
+      savon (~> 2.12)
 
 GEM
   remote: https://rubygems.org/
@@ -90,6 +90,8 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     akami (1.3.1)
       gyoku (>= 0.4.0)
       nokogiri
@@ -125,7 +127,7 @@ GEM
     gyoku (1.3.1)
       builder (>= 2.1.2)
     httpclient (2.8.3)
-    httpi (2.4.4)
+    httpi (2.4.5)
       rack
       socksify
     i18n (1.8.2)
@@ -166,6 +168,7 @@ GEM
     pry (0.13.0)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    public_suffix (4.0.6)
     puma (3.12.6)
     racc (1.5.2)
     rack (2.2.3)
@@ -212,7 +215,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    savon (2.12.0)
+    savon (2.12.1)
       akami (~> 1.2)
       builder (>= 2.1.2)
       gyoku (~> 1.2)
@@ -242,7 +245,8 @@ GEM
     us_web_design_standards (0.0.2)
       railties
       sass (~> 3.4)
-    wasabi (3.5.0)
+    wasabi (3.6.1)
+      addressable
       httpi (~> 2.0)
       nokogiri (>= 1.4.2)
     web-console (3.7.0)


### PR DESCRIPTION
We were on ruby-bgs 0.2, but mimemagic required a nokogiri update
that was too new; 0.3 has a compatible version so I updated that.