### PR TITLE
Pass proper VVA_FILE_NUM to VvaService

### DIFF
--- a/app/services/vva_service.rb
+++ b/app/services/vva_service.rb
@@ -18,7 +18,14 @@ class VVAService < MonitorService
     # All failures in the call to get_by_claim_number (invalid login credentials, file number too short)
     # should raise a VVA::SOAPError. If the call to get_by_claim_number succeeds then @pass will be true,
     # even if there are no documents.
-    @client.document_list.get_by_claim_number(Rails.application.secrets.vva_file_num)
+
+    # Use ENV variable directly here instead of Rails.application.secrets because ERB.new() is converting input numbers
+    # with leading zeroes to integers and changing their value as a result. Our current production VVA_FILE_NUM starts
+    # with a zero, so VVA status checks were failing.
+    # 
+    # Reference: https://github.com/rails/rails/blob/5-2-stable/railties/lib/rails/secrets.rb#L29
+    # Example failure: YAML.load(ERB.new("example: 012345").result) # => {"example"=>5349}
+    @client.document_list.get_by_claim_number(ENV["VVA_FILE_NUM"])
     @pass = true
   end
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -14,7 +14,6 @@ development:
   secret_key_base: 04a0351cab89c791a1cd8fde430a586110737610f31eee5a5b86ae3e405d71955891ac3f55382dc54102ad4fba25f62d920c61e93a6c1be321c8bef4c1d5ad4d
   target_file_num: <%= ENV["TARGET_FILE_NUM"] %>
   participant_ids: <%= ENV["PARTICIPANT_IDS"] %>
-  vva_file_num: <%= ENV["VVA_FILE_NUM"] %>
   dms_checker_staff_key: <%= ENV["DMS_CHECKER_STAFF_KEY"] %>
 
 test:
@@ -26,6 +25,4 @@ production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   target_file_num: <%= ENV["TARGET_FILE_NUM"] %>
   participant_ids: <%= ENV["PARTICIPANT_IDS"] %>
-  # Use ENV variable directly in code due to shortcoming explained in more detail in vva_service.rb
-  # vva_file_num: <%= ENV["VVA_FILE_NUM"] %>
   dms_checker_staff_key: <%= ENV["DMS_CHECKER_STAFF_KEY"] %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -26,5 +26,6 @@ production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
   target_file_num: <%= ENV["TARGET_FILE_NUM"] %>
   participant_ids: <%= ENV["PARTICIPANT_IDS"] %>
-  vva_file_num: <%= ENV["VVA_FILE_NUM"] %>
+  # Use ENV variable directly in code due to shortcoming explained in more detail in vva_service.rb
+  # vva_file_num: <%= ENV["VVA_FILE_NUM"] %>
   dms_checker_staff_key: <%= ENV["DMS_CHECKER_STAFF_KEY"] %>


### PR DESCRIPTION
Use ENV variable directly in code instead of `Rails.application.secrets` because [`ERB.new()` is converting input numbers with leading zeroes to integers](https://github.com/rails/rails/blob/5-2-stable/railties/lib/rails/secrets.rb#L29) and changing their value as a result. Our current production VVA_FILE_NUM starts with a zero, so VVA status checks were failing.

Example failure that we're encountering in `prod` and sidestepping with this fix:
```ruby
rails c> YAML.load(ERB.new("example: 012345").result)
=> {"example"=>5349}
```

[Related Slack thread](https://dsva.slack.com/archives/CAM9FJ85P/p1627315355471500).