### PR TITLE
APPEALS-39923: Add Find Contentions By Participant Id to Caseflow Monitor

### DIFF
--- a/app/jobs/monitor_job.rb
+++ b/app/jobs/monitor_job.rb
@@ -49,6 +49,7 @@ class MonitorJob < ActiveJob::Base
       services = [
         Fakes::BGSAddressService,
         Fakes::BGSBenefitsService,
+        Fakes::BGSContentionsByParticipantIdService,
         Fakes::BGSClaimantFlashesService,
         Fakes::BGSClaimantGeneralInfoService,
         Fakes::BGSOrganizationPoaService,
@@ -67,6 +68,7 @@ class MonitorJob < ActiveJob::Base
       services = [
         BGSAddressService,
         BGSBenefitsService,
+        BGSContentionsByParticipantIdService,
         BGSClaimantFlashesService,
         BGSClaimantGeneralInfoService,
         BGSOrganizationPoaService,

--- a/app/services/bgs_contentions_by_participant_id_service.rb
+++ b/app/services/bgs_contentions_by_participant_id_service.rb
@@ -1,0 +1,51 @@
+require "benchmark"
+
+class BGSContentionsByParticipantIdService < MonitorService
+  attr_accessor :last_result, :name
+  @@service_name = "BGS.ContentionsByParticipantIdService"
+
+  def initialize
+
+    @bgs_client = init_client
+
+    @name = @@service_name
+    @service = "Contention"
+    @env = ENV['BGS_ENVIRONMENT']
+    @api = "findContentionByParticipantId"
+    super
+  end
+
+  def query_service
+    participant_id = Rails.application.secrets.participant_ids.split(",").sample.strip
+    contentions = @bgs_client.contention.find_contention_by_participant_id(participant_id)
+    if !contention.nil?
+      @pass = true
+    end
+  end
+
+
+  def self.service_name
+    @@service_name
+  end
+
+  def self.prevalidate
+    return ENV.key?("BGS_ENVIRONMENT")
+  end
+
+  private
+
+  def init_client
+    BGS::Services.new(
+      env: ENV["BGS_ENVIRONMENT"],
+      application: "CASEFLOW",
+      client_ip: ENV["BGS_IP_ADDRESS"],
+      client_station_id: ENV["BGS_STATION_ID"],
+      client_username: ENV["BGS_USERNAME"],
+      ssl_cert_key_file: ENV["BGS_KEY_LOCATION"],
+      ssl_cert_file: ENV["BGS_CERT_LOCATION"],
+      ssl_ca_cert: ENV["BGS_CA_CERT_LOCATION"],
+      forward_proxy_url: ENV["RUBY_BGS_PROXY_BASE_URL"],
+      log: true
+    )
+  end
+end

--- a/lib/fakes/bgs_contentions_by_participant_id_service.rb
+++ b/lib/fakes/bgs_contentions_by_participant_id_service.rb
@@ -1,0 +1,26 @@
+class Fakes::BGSContentionsByParticipantIdService < MonitorService
+    attr_accessor :last_result
+    @@service_name = "BGS.ContentionsByParticipantIdService"
+  
+    def initialize
+      @name = @@service_name
+      @service = "Contention"
+      @env = "beplinktest"
+      @api = "findContentionByParticipantId"
+      super
+    end
+  
+    def self.service_name
+      @@service_name
+    end
+  
+    def query_service
+      @pass = true
+    end
+  
+    def self.prevalidate
+      true
+    end
+  
+  end
+  


### PR DESCRIPTION
Resolves [APPEALS-39923](https://jira.devops.va.gov/browse/APPEALS-39923)

Adds bgs.find_contention_by_participant_id call to caseflow monitor. 