### PR TITLE
MattT/BPS-46847: Update connect_vbms gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,10 +13,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect_vbms.git
-  revision: 6e5d45fc5f69cdfce1ee8a9edb9b4ff7dd9c80c5
+  revision: 1834cf61310001c82e2e96d665518407c3bce947
   branch: master
   specs:
-    connect_vbms (1.2.0)
+    connect_vbms (1.4.0)
       httpclient (~> 2.8.0)
       httpi (~> 2.4)
       mail
@@ -109,10 +109,11 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.3.1)
     crass (1.0.6)
     d3-rails (5.9.2)
       railties (>= 3.1)
+    digest (3.1.1)
     dogapi (1.39.0)
       multi_json
     dotenv (2.7.5)
@@ -127,11 +128,12 @@ GEM
     gyoku (1.3.1)
       builder (>= 2.1.2)
     httpclient (2.8.3)
-    httpi (2.4.5)
+    httpi (2.5.0)
       rack
       socksify
-    i18n (1.8.2)
+    i18n (1.14.5)
       concurrent-ruby (~> 1.0)
+    io-wait (0.3.1)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
     jquery-rails (4.3.5)
@@ -147,24 +149,40 @@ GEM
     loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.1)
+    mail (2.8.1)
       mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
     mimemagic (0.3.7)
       nokogiri (~> 1.11.2)
-    mini_mime (1.0.2)
-    mini_portile2 (2.5.0)
-    minitest (5.14.0)
+    mini_mime (1.1.2)
+    mini_portile2 (2.5.3)
+    minitest (5.15.0)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
     multi_json (1.14.1)
     neat (1.7.4)
       bourbon (>= 4.0)
       sass (>= 3.3)
+    net-imap (0.2.2)
+      digest
+      net-protocol
+      strscan
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.1.2)
+      io-wait
+      timeout
+    net-smtp (0.3.0)
+      digest
+      net-protocol
+      timeout
     nio4r (2.5.2)
-    nokogiri (1.11.2)
+    nokogiri (1.11.7)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     nori (2.6.0)
@@ -173,8 +191,8 @@ GEM
       method_source (~> 1.0)
     public_suffix (4.0.6)
     puma (3.12.6)
-    racc (1.5.2)
-    rack (2.2.3)
+    racc (1.8.0)
+    rack (2.2.9)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.4.2)
@@ -237,13 +255,15 @@ GEM
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
     sqlite3 (1.4.0)
+    strscan (3.1.0)
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
+    timeout (0.4.0)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
-    tzinfo (1.2.6)
+    tzinfo (1.2.11)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
@@ -264,13 +284,13 @@ GEM
     websocket-extensions (0.1.5)
     xmldsig (0.3.2)
       nokogiri
-    xmlenc (0.7.1)
+    xmlenc (0.8.0)
       activemodel (>= 3.0.0)
       activesupport (>= 3.0.0)
       nokogiri (>= 1.6.0, < 2.0.0)
       xmlmapper (>= 0.7.3)
-    xmlmapper (0.7.3)
-      nokogiri (~> 1.5)
+    xmlmapper (0.8.1)
+      nokogiri (~> 1.11)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
In support of [BPS-46837](https://jira.devops.va.gov/browse/BPS-46847).

Updates the version of the connect_vbms gem utilized by the Caseflow Monitor application in order to address a log4j vulnerability.